### PR TITLE
Use regex to convert path parameters from OpenAPI to koa-router notation

### DIFF
--- a/lib/util/string.js
+++ b/lib/util/string.js
@@ -7,7 +7,7 @@ import urljoin from 'url-join';
  * @param version string, like 1.0.1
  * @return {major: 1, minor: 0, patch: 1}
  */
-function version (version) {
+function version(version) {
   const vers = _.split(version, '.');
 
   return {
@@ -50,24 +50,22 @@ function versionApi(enable, ver, baseUrl = '/', endpoint = '') {
 }
 
 /**
- * convert swagger url format to koa-router url
- * ps: api/test/{id} --> api/test/:id
- * @param  {[type]} path [description]
- * @return {[type]}      [description]
+ * Convert path segment parameters from OpenAPI notation to koa-router notation.
+ * @param  {string}  pathSegment like '{people}' (OpenAPI)
+ * @return {string}  koa-router path segment like ':people'
  */
-function routerFormat (path) {
-  if (!path || typeof(path) != 'string') return '';
+function openApiToKoa(pathSegment) {
+  return pathSegment.replace(/^\{(.+)\}$/, ':$1');
+}
 
-  let params = _.words(path, /{([\s\S]+?)}/g)
-  let data = {};
-  _.forEach(params, function (param) {
-    param = param.replace(/[{|}]/g, '');
-    data[param] = `:${param}`
-  })
-
-  _.templateSettings.interpolate = /{([\s\S]+?)}/g;
-  var compiled = _.template(path);
-  return compiled(data);
+/**
+ * Converts URL paths from OpenAPI format to koa-router format.
+ * @param  {string} path OpenAPI path like 'api/test/{id}'
+ * @return {string}      koa-router path like 'api/test/:id'
+ */
+function routerFormat(path) {
+  if (!path || typeof path != 'string') return '';
+  return _.map(path.split('/'), openApiToKoa).join('/');
 }
 
 export {

--- a/test/string.js
+++ b/test/string.js
@@ -48,4 +48,5 @@ test('routerFormat', (t)=> {
   t.is(routerFormat('/api/{peopleId}'), '/api/:peopleId');
   t.is(routerFormat('/api/{peopleId}/{mailId}'), '/api/:peopleId/:mailId');
   t.is(routerFormat('/api/{peopleId}/{mailId}/{attachId}'), '/api/:peopleId/:mailId/:attachId');
+  t.is(routerFormat('/api/{people-id}/{mail-id}/{attach-id}'), '/api/:people-id/:mail-id/:attach-id');
 })


### PR DESCRIPTION
This enables support for path parameters with hyphens in them.